### PR TITLE
Add support for CUDA compute capability 5.x

### DIFF
--- a/hwloc/topology-cuda.c
+++ b/hwloc/topology-cuda.c
@@ -84,6 +84,8 @@ static unsigned hwloc_cuda_cores_per_MP(int major, int minor)
       break;
     case 3:
       return 192;
+    case 5:
+      return 128;
   }
   hwloc_debug("unknown compute capability %u.%u, disabling core display.\n", major, minor);
   return 0;


### PR DESCRIPTION
To support getting the number of cores on CUDA hardware capable of compute capability 5.x the corresponding switch statement has to be etended.
See: http://docs.nvidia.com/cuda/cuda-c-programming-guide/#architecture-5-x